### PR TITLE
Fix warning "dir /nonexistent can't be accessed"

### DIFF
--- a/deb/postinst.sh
+++ b/deb/postinst.sh
@@ -1,1 +1,1 @@
-adduser --no-create-home --home /nonexistent --group --system yubihsm-connector
+adduser --no-create-home --group --system yubihsm-connector


### PR DESCRIPTION
```
Setting up yubihsm-connector (2.1.0-1) ...
Warning: The home dir /nonexistent you specified can't be accessed: No such file or directory
Adding system user `yubihsm-connector' (UID 127) ...
Adding new group `yubihsm-connector' (GID 137) ...
Adding new user `yubihsm-connector' (UID 127) with group `yubihsm-connector' ...
Not creating home directory `/nonexistent'.
Setting up libyubihsm1 (2.0.2-1) ...
```