### PR TITLE
Fix winusb issues under esxi

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -44,6 +44,14 @@ See the configured [hooks](.pre-commit-config.yaml) for details.
 $ make
 ....
 
+=== Cross-compiling for Windows
+
+To make this work you need to have mingw-w64 installed.
+
+....
+GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build
+....
+
 === Linting
 
 ....

--- a/api.go
+++ b/api.go
@@ -138,7 +138,7 @@ func statusHandler(w http.ResponseWriter, r *http.Request, timeout time.Duration
 	})
 
 	var status string
-	if err = usbReopen(cid, timeout, serial); err != nil {
+	if err = usbCheck(cid, timeout, serial); err != nil {
 		status = "NO_DEVICE"
 		clog.WithError(err).Warn("status failed to open usb device")
 	} else {

--- a/api.go
+++ b/api.go
@@ -138,7 +138,7 @@ func statusHandler(w http.ResponseWriter, r *http.Request, timeout time.Duration
 	})
 
 	var status string
-	if err = usbReopen(cid, fmt.Errorf("status request"), timeout, serial); err != nil {
+	if err = usbReopen(cid, timeout, serial); err != nil {
 		status = "NO_DEVICE"
 		clog.WithError(err).Warn("status failed to open usb device")
 	} else {

--- a/build_win
+++ b/build_win
@@ -1,0 +1,1 @@
+GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build

--- a/build_win
+++ b/build_win
@@ -1,1 +1,0 @@
-GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build

--- a/usb_libusb.go
+++ b/usb_libusb.go
@@ -156,7 +156,7 @@ func usbreopen(cid string, why error, serial string) (err error) {
 	return usbopen(cid, serial)
 }
 
-func usbReopen(cid string, why error, _ time.Duration, serial string) (err error) {
+func usbReopen(cid string, _ time.Duration, serial string) (err error) {
 	state.mtx.Lock()
 	defer state.mtx.Unlock()
 
@@ -171,7 +171,7 @@ func usbReopen(cid string, why error, _ time.Duration, serial string) (err error
 				"Error":          err,
 			}).Debug("Couldn't read serial number from device")
 
-			if err = usbreopen(cid, why, serial); err != nil {
+			if err = usbreopen(cid, err, serial); err != nil {
 				return err
 			}
 			continue

--- a/usb_libusb.go
+++ b/usb_libusb.go
@@ -156,7 +156,7 @@ func usbreopen(cid string, why error, serial string) (err error) {
 	return usbopen(cid, serial)
 }
 
-func usbReopen(cid string, _ time.Duration, serial string) (err error) {
+func usbCheck(cid string, _ time.Duration, serial string) (err error) {
 	state.mtx.Lock()
 	defer state.mtx.Unlock()
 

--- a/usb_windows.c
+++ b/usb_windows.c
@@ -463,6 +463,11 @@ void usbClose(PDEVICE_CONTEXT* device)
     *device = NULL;
 }
 
+DWORD usbCheck(PDEVICE_CONTEXT device, char* serialNumber)
+{
+    return ERROR_SUCCESS;
+}
+
 DWORD usbWrite(PDEVICE_CONTEXT device, PUCHAR buffer, ULONG bufferSizeInBytes, PULONG bytesTransferred)
 {
     if (!device || !device->initialized)

--- a/usb_windows.c
+++ b/usb_windows.c
@@ -463,9 +463,9 @@ void usbClose(PDEVICE_CONTEXT* device)
     *device = NULL;
 }
 
-DWORD usbCheck(PDEVICE_CONTEXT device, int vendorId, int productId, char* serialNumber)
+DWORD usbCheck(PDEVICE_CONTEXT device, int vendorId, int productId)
 {
-    if (!IsMatchingDevice(device->usbInterface, vendorId, productId, serialNumber))
+    if (!IsMatchingDevice(device->usbInterface, vendorId, productId, NULL))
     {
         return ERROR_OBJECT_NOT_FOUND;
     }

--- a/usb_windows.c
+++ b/usb_windows.c
@@ -341,24 +341,7 @@ static DWORD GetUsbDevice(int vendorId, int productId, char* serialNumber, PDEVI
         }
 
         {
-            // we set up a dummy read with a 10ms timeout here, if the timeout is too
-            // short this times out before it has time to complete. The reason for
-            // doing this is that there might be data left in the device buffers from
-            // earlier transactions, this should flush it.
-            BYTE buf[2048];
-            ULONG transferred = 0;
-            ULONG timeout = 10;
-
-            if (!WinUsb_SetPipePolicy(interfaceHandle, PIPE_READ, PIPE_TRANSFER_TIMEOUT,
-                    sizeof(timeout), &timeout)) {
-                error = GetLastError();
-                continue;
-            }
-
-            // we don't really care about what happens to this read request..
-            WinUsb_ReadPipe(interfaceHandle, PIPE_READ, buf, sizeof(buf), &transferred, 0);
-
-            timeout = confTimeout;
+            ULONG timeout = confTimeout;
             if (!WinUsb_SetPipePolicy(interfaceHandle, PIPE_READ, PIPE_TRANSFER_TIMEOUT,
                     sizeof(timeout), &timeout)) {
                 error = GetLastError();
@@ -478,26 +461,6 @@ void usbClose(PDEVICE_CONTEXT* device)
 
     free(deref);
     *device = NULL;
-}
-
-DWORD usbReopen(PDEVICE_CONTEXT device)
-{
-    if (!device || !device->initialized)
-    {
-        return ERROR_INVALID_STATE;
-    }
-
-    if (!WinUsb_ResetPipe(device->usbInterface, device->readPipe))
-    {
-        return GetLastError();
-    }
-
-    if (!WinUsb_ResetPipe(device->usbInterface, device->writePipe))
-    {
-        return GetLastError();
-    }
-
-    return ERROR_SUCCESS;
 }
 
 DWORD usbWrite(PDEVICE_CONTEXT device, PUCHAR buffer, ULONG bufferSizeInBytes, PULONG bytesTransferred)

--- a/usb_windows.c
+++ b/usb_windows.c
@@ -465,10 +465,16 @@ void usbClose(PDEVICE_CONTEXT* device)
 
 DWORD usbCheck(PDEVICE_CONTEXT device, int vendorId, int productId)
 {
+    if (!device || !device->initialized)
+    {
+        return ERROR_INVALID_STATE;
+    }
+
     if (!IsMatchingDevice(device->usbInterface, vendorId, productId, NULL))
     {
         return ERROR_OBJECT_NOT_FOUND;
     }
+
     return ERROR_SUCCESS;
 }
 

--- a/usb_windows.c
+++ b/usb_windows.c
@@ -325,14 +325,6 @@ static DWORD GetUsbDevice(int vendorId, int productId, char* serialNumber, PDEVI
             continue;
         }
 
-        // This is vitally important since it declares that ZLP should be sent when a message
-        // would otherwise end on a packet boundary.
-        if (!WinUsb_SetPipePolicy(interfaceHandle, PIPE_WRITE,
-                SHORT_PACKET_TERMINATE, 1, (PVOID) "\x1")) {
-            error = GetLastError();
-            continue;
-        }
-
         if (!IsMatchingDevice(interfaceHandle, vendorId, productId, serialNumber))
         {
             // Set an error in case this is the last iteration of the loop.
@@ -350,6 +342,14 @@ static DWORD GetUsbDevice(int vendorId, int productId, char* serialNumber, PDEVI
 
             if (!WinUsb_SetPipePolicy(interfaceHandle, PIPE_WRITE, PIPE_TRANSFER_TIMEOUT,
                     sizeof(timeout), &timeout)) {
+                error = GetLastError();
+                continue;
+            }
+
+            // This is vitally important since it declares that ZLP should be sent when a message
+            // would otherwise end on a packet boundary.
+            if (!WinUsb_SetPipePolicy(interfaceHandle, PIPE_WRITE,
+                    SHORT_PACKET_TERMINATE, 1, (PVOID) "\x1")) {
                 error = GetLastError();
                 continue;
             }

--- a/usb_windows.c
+++ b/usb_windows.c
@@ -463,8 +463,12 @@ void usbClose(PDEVICE_CONTEXT* device)
     *device = NULL;
 }
 
-DWORD usbCheck(PDEVICE_CONTEXT device, char* serialNumber)
+DWORD usbCheck(PDEVICE_CONTEXT device, int vendorId, int productId, char* serialNumber)
 {
+    if (!IsMatchingDevice(device->usbInterface, vendorId, productId, serialNumber))
+    {
+        return ERROR_OBJECT_NOT_FOUND;
+    }
     return ERROR_SUCCESS;
 }
 

--- a/usb_windows.h
+++ b/usb_windows.h
@@ -38,7 +38,7 @@ typedef struct DEVICE_CONTEXT
 
 extern DWORD usbOpen(int vendorId, int productId, char* serialNumber, PDEVICE_CONTEXT* device, ULONG timeout);
 extern void  usbClose(PDEVICE_CONTEXT* device);
-extern DWORD usbCheck(PDEVICE_CONTEXT device, char* serialNumber);
+extern DWORD usbCheck(PDEVICE_CONTEXT device, int vendorId, int productId, char* serialNumber);
 extern DWORD usbWrite(PDEVICE_CONTEXT device, PUCHAR buffer, ULONG bufferSizeInBytes, PULONG bytesTransferred);
 extern DWORD usbRead(PDEVICE_CONTEXT device, PUCHAR buffer, ULONG bufferSizeInBytes, PULONG bytesTransferred);
 

--- a/usb_windows.h
+++ b/usb_windows.h
@@ -38,7 +38,7 @@ typedef struct DEVICE_CONTEXT
 
 extern DWORD usbOpen(int vendorId, int productId, char* serialNumber, PDEVICE_CONTEXT* device, ULONG timeout);
 extern void  usbClose(PDEVICE_CONTEXT* device);
-extern DWORD usbCheck(PDEVICE_CONTEXT device, int vendorId, int productId, char* serialNumber);
+extern DWORD usbCheck(PDEVICE_CONTEXT device, int vendorId, int productId);
 extern DWORD usbWrite(PDEVICE_CONTEXT device, PUCHAR buffer, ULONG bufferSizeInBytes, PULONG bytesTransferred);
 extern DWORD usbRead(PDEVICE_CONTEXT device, PUCHAR buffer, ULONG bufferSizeInBytes, PULONG bytesTransferred);
 

--- a/usb_windows.h
+++ b/usb_windows.h
@@ -38,6 +38,7 @@ typedef struct DEVICE_CONTEXT
 
 extern DWORD usbOpen(int vendorId, int productId, char* serialNumber, PDEVICE_CONTEXT* device, ULONG timeout);
 extern void  usbClose(PDEVICE_CONTEXT* device);
+extern DWORD usbCheck(PDEVICE_CONTEXT device, char* serialNumber);
 extern DWORD usbWrite(PDEVICE_CONTEXT device, PUCHAR buffer, ULONG bufferSizeInBytes, PULONG bytesTransferred);
 extern DWORD usbRead(PDEVICE_CONTEXT device, PUCHAR buffer, ULONG bufferSizeInBytes, PULONG bytesTransferred);
 

--- a/usb_windows.h
+++ b/usb_windows.h
@@ -38,7 +38,6 @@ typedef struct DEVICE_CONTEXT
 
 extern DWORD usbOpen(int vendorId, int productId, char* serialNumber, PDEVICE_CONTEXT* device, ULONG timeout);
 extern void  usbClose(PDEVICE_CONTEXT* device);
-extern DWORD usbReopen(PDEVICE_CONTEXT device);
 extern DWORD usbWrite(PDEVICE_CONTEXT device, PUCHAR buffer, ULONG bufferSizeInBytes, PULONG bytesTransferred);
 extern DWORD usbRead(PDEVICE_CONTEXT device, PUCHAR buffer, ULONG bufferSizeInBytes, PULONG bytesTransferred);
 

--- a/usb_winusb.go
+++ b/usb_winusb.go
@@ -104,7 +104,7 @@ func usbreopen(cid string, why error, timeout time.Duration, serial string) (err
 	return usbopen(cid, timeout, serial)
 }
 
-func usbReopen(cid string, timeout time.Duration, serial string) (err error) {
+func usbCheck(cid string, timeout time.Duration, serial string) (err error) {
 	device.mtx.Lock()
 	defer device.mtx.Unlock()
 

--- a/usb_winusb.go
+++ b/usb_winusb.go
@@ -147,7 +147,7 @@ func usbwrite(buf []byte, cid string) (err error) {
 out:
 	log.WithFields(log.Fields{
 		"Correlation-ID": cid,
-		"n":              n,
+		"n":              uint(n),
 		"err":            err,
 		"len":            len(buf),
 		"buf":            buf,
@@ -174,7 +174,7 @@ func usbread(cid string) (buf []byte, err error) {
 out:
 	log.WithFields(log.Fields{
 		"Correlation-ID": cid,
-		"n":              n,
+		"n":              uint(n),
 		"err":            err,
 		"len":            len(buf),
 		"buf":            buf,

--- a/usb_winusb.go
+++ b/usb_winusb.go
@@ -108,7 +108,7 @@ func usbReopen(cid string, why error, timeout time.Duration, serial string) (err
 	device.mtx.Lock()
 	defer device.mtx.Unlock()
 
-	if err = usbopen(cid, timout, serial); err != nil {
+	if err = usbopen(cid, timeout, serial); err != nil {
 		return err
 	}
 
@@ -187,14 +187,14 @@ func usbProxy(req []byte, cid string, timeout time.Duration, serial string) (res
 
 	for {
 		if err = usbwrite(req, cid); err != nil {
-			if err = usbreopen(cid, err, serial); err != nil {
+			if err = usbreopen(cid, err, timeout, serial); err != nil {
 				return nil, err
 			}
 			continue
 		}
 
 		if resp, err = usbread(cid); err != nil {
-			if err = usbreopen(cid, err, timout, serial); err != nil {
+			if err = usbreopen(cid, err, timeout, serial); err != nil {
 				return nil, err
 			}
 			continue

--- a/usb_winusb.go
+++ b/usb_winusb.go
@@ -100,16 +100,6 @@ func usbreopen(cid string, why error, timeout time.Duration, serial string) (err
 		"why":            why,
 	}).Debug("reopening usb context")
 
-	// If the first request to the connector is a status request,
-	// the device context might not have been created yet.
-	if device.ctx != nil {
-		if err = winusbError(C.usbReopen(device.ctx)); err != nil {
-			log.WithField(
-				"Correlation-ID", cid,
-			).WithError(err).Error("unable to reset device")
-		}
-	}
-
 	usbclose(cid)
 	return usbopen(cid, timeout, serial)
 }

--- a/usb_winusb.go
+++ b/usb_winusb.go
@@ -112,11 +112,8 @@ func usbReopen(cid string, why error, timeout time.Duration, serial string) (err
 		return err
 	}
 
-	cSerial := C.CString(serial)
-	defer C.free(unsafe.Pointer(cSerial))
-
 	for {
-		if err = winusbError(C.usbCheck(device.ctx, 0x1050, 0x0030, cSerial)); err != nil {
+		if err = winusbError(C.usbCheck(device.ctx, 0x1050, 0x0030)); err != nil {
 			log.WithFields(log.Fields{
 				"Correlation-ID": cid,
 				"Error":          err,

--- a/usb_winusb.go
+++ b/usb_winusb.go
@@ -104,7 +104,7 @@ func usbreopen(cid string, why error, timeout time.Duration, serial string) (err
 	return usbopen(cid, timeout, serial)
 }
 
-func usbReopen(cid string, why error, timeout time.Duration, serial string) (err error) {
+func usbReopen(cid string, timeout time.Duration, serial string) (err error) {
 	device.mtx.Lock()
 	defer device.mtx.Unlock()
 
@@ -119,7 +119,7 @@ func usbReopen(cid string, why error, timeout time.Duration, serial string) (err
 				"Error":          err,
 			}).Debug("Couldn't check usb context")
 
-			if err = usbreopen(cid, why, timeout, serial); err != nil {
+			if err = usbreopen(cid, err, timeout, serial); err != nil {
 				return err
 			}
 			continue

--- a/usb_winusb.go
+++ b/usb_winusb.go
@@ -142,18 +142,6 @@ func usbwrite(buf []byte, cid string) (err error) {
 		goto out
 	}
 
-	if len(buf)%64 == 0 {
-		var empty []byte
-
-		if err = winusbError(C.usbWrite(
-			device.ctx,
-			(*C.UCHAR)(unsafe.Pointer(&buf[0])),
-			C.ULONG(len(empty)),
-			&n)); err != nil {
-			goto out
-		}
-	}
-
 out:
 	log.WithFields(log.Fields{
 		"Correlation-ID": cid,

--- a/usb_winusb.go
+++ b/usb_winusb.go
@@ -116,7 +116,7 @@ func usbReopen(cid string, why error, timeout time.Duration, serial string) (err
 	defer C.free(unsafe.Pointer(cSerial))
 
 	for {
-		if err = winusbError(C.usbCheck(device.ctx, cSerial)); err != nil {
+		if err = winusbError(C.usbCheck(device.ctx, 0x1050, 0x0030, cSerial)); err != nil {
 			log.WithFields(log.Fields{
 				"Correlation-ID": cid,
 				"Error":          err,

--- a/usb_winusb.go
+++ b/usb_winusb.go
@@ -112,6 +112,25 @@ func usbReopen(cid string, why error, timeout time.Duration, serial string) (err
 		return err
 	}
 
+	cSerial := C.CString(serial)
+	defer C.free(unsafe.Pointer(cSerial))
+
+	for {
+		if err = winusbError(C.usbCheck(device.ctx, cSerial)); err != nil {
+			log.WithFields(log.Fields{
+				"Correlation-ID": cid,
+				"Error":          err,
+			}).Debug("Couldn't check usb context")
+
+			if err = usbreopen(cid, why, timeout, serial); err != nil {
+				return err
+			}
+			continue
+		}
+
+		break
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adresses a 2s delay in the status endpoint when run on Windows under ESXi. It essentially does what PR#19 did for libusb but for WinUsb. It now also has a couple of bug fixes that were discovered while implementing & testing.

The delay happens in the 'drain pipe' WinUsb_ReadPipe call, which takes 2s to execute when running under ESXi, despite having set the timeout pipe policy to 10 ms. It Doesn't do that on a physical Windows machine. This is not a big deal now since we only reopen the device on errors.