### PR TITLE
Removing lgtm.yml

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,6 +1,0 @@
----
-extraction:
-  go:
-    prepare:
-      packages:
-        - libusb-1.0-0-dev


### PR DESCRIPTION
Since GitHub's CodeQL action doesn't appear to use this file and we're deduping with the LGTM app, removing the yml. 