### PR TITLE
systemd service unit: drop superfluous comments

### DIFF
--- a/deb/yubihsm-connector.service
+++ b/deb/yubihsm-connector.service
@@ -1,3 +1,6 @@
+; https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+; https://www.freedesktop.org/software/systemd/man/systemd.service.html
+
 [Unit]
 Description=YubiHSM connector
 Documentation=https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-connector/
@@ -6,20 +9,12 @@ Wants=network-online.target systemd-networkd-wait-online.service
 
 [Service]
 Restart=on-abnormal
-
-; User and group the process will run as.
 User=yubihsm-connector
 Group=yubihsm-connector
-
 ExecStart=/usr/bin/yubihsm-connector -c /etc/yubihsm-connector.yaml
-
-; Use private /tmp and /var/tmp, which are discarded after caddy stops.
 PrivateTmp=true
-; Hide /home, /root, and /run/user. Nobody will steal your SSH-keys.
 ProtectHome=true
-; Make /usr, /boot, /etc and possibly some more folders read-only.
 ProtectSystem=full
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
- Remove unrelated 'after caddy stops' comment.

- Anyone interested in understanding the directives can refer directly
    to systemd documentation:

    * https://www.freedesktop.org/software/systemd/man/systemd.exec.html
    * https://www.freedesktop.org/software/systemd/man/systemd.service.html