### PR TITLE
fix: Allow host-header-allowlist to be set in configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ resources/win-installer/Debug/
 resources/win-installer/Release/
 resources/win-installer/.vs
 resources/win-installer/installer/obj/
+yubihsm-connector

--- a/api.go
+++ b/api.go
@@ -94,7 +94,7 @@ func middlewareWrapper(next http.HandlerFunc) http.HandlerFunc {
 			}
 		}()
 
-		if hostHeaderAllowlisting && !validateHost(r.Host) {
+		if config.EnableHostHeaderAllowlist && !validateHost(r.Host) {
 			clog.WithField("host", r.Host).Error("host not in allowlist")
 			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 			return
@@ -235,10 +235,11 @@ func extractHost(addr string) string {
 
 func validateHost(addr string) bool {
 	host := extractHost(addr)
-	for _, h := range hostHeaderAllowlist {
+	for _, h := range config.HostHeaderAllowlist {
 		if h == host {
 			return true
 		}
 	}
+
 	return false
 }

--- a/main.go
+++ b/main.go
@@ -37,11 +37,12 @@ import (
 	"github.com/spf13/viper"
 )
 
-var (
-	// Host header allowlisting
-	hostHeaderAllowlisting bool
-	hostHeaderAllowlist    = []string{"localhost", "localhost.", "127.0.0.1", "[::1]"}
-)
+type Config struct {
+	HostHeaderAllowlist       []string `mapstructure:"host-header-allowlist"`
+	EnableHostHeaderAllowlist bool     `mapstructure:"enable-host-header-allowlist"`
+}
+
+var config Config
 
 type program struct {
 	srv *http.Server
@@ -154,6 +155,11 @@ func main() {
 					return err
 				}
 			}
+
+			if err := viper.Unmarshal(&config); err != nil {
+				return err
+			}
+
 			if viper.GetBool("debug") {
 				log.SetLevel(log.DebugLevel)
 			}
@@ -190,24 +196,34 @@ func main() {
 	}
 	rootCmd.PersistentFlags().StringP("config", "c", "", "config file")
 	viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
+
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "debug output")
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
+
 	rootCmd.PersistentFlags().BoolP("seccomp", "s", false, "enable seccomp")
 	viper.BindPFlag("seccomp", rootCmd.PersistentFlags().Lookup("seccomp"))
-	rootCmd.PersistentFlags().StringP("cert", "", "", "certificate (X509)")
+
+	rootCmd.PersistentFlags().String("cert", "", "certificate (X509)")
 	viper.BindPFlag("cert", rootCmd.PersistentFlags().Lookup("cert"))
-	rootCmd.PersistentFlags().StringP("key", "", "", "certificate key")
+
+	rootCmd.PersistentFlags().String("key", "", "certificate key")
 	viper.BindPFlag("key", rootCmd.PersistentFlags().Lookup("key"))
-	rootCmd.PersistentFlags().StringP("serial", "", "", "device serial")
+
+	rootCmd.PersistentFlags().String("serial", "", "device serial")
 	viper.BindPFlag("serial", rootCmd.PersistentFlags().Lookup("serial"))
+
 	rootCmd.PersistentFlags().StringP("listen", "l", "localhost:12345", "listen address")
 	viper.BindPFlag("listen", rootCmd.PersistentFlags().Lookup("listen"))
+
 	rootCmd.PersistentFlags().BoolP("syslog", "L", false, "log to syslog/eventlog")
 	viper.BindPFlag("syslog", rootCmd.PersistentFlags().Lookup("syslog"))
-	rootCmd.PersistentFlags().BoolVar(&hostHeaderAllowlisting, "enable-host-header-allowlist", false, "Enable Host header allowlisting")
-	viper.BindPFlag("enable-host-allowlist", rootCmd.PersistentFlags().Lookup("enable-host-header-allowlist"))
-	rootCmd.PersistentFlags().StringSliceVar(&hostHeaderAllowlist, "host-header-allowlist", hostHeaderAllowlist, "Host header allowlist")
-	viper.BindPFlag("host-allowlist", rootCmd.PersistentFlags().Lookup("host-header-allowlist"))
+
+	rootCmd.PersistentFlags().Bool("enable-host-header-allowlist", false, "Enable Host header allowlisting")
+	viper.BindPFlag("enable-host-header-allowlist", rootCmd.PersistentFlags().Lookup("enable-host-header-allowlist"))
+
+	rootCmd.PersistentFlags().StringSlice("host-header-allowlist", []string{"localhost", "localhost.", "127.0.0.1", "[::1]"}, "Host header allowlist")
+	viper.BindPFlag("host-header-allowlist", rootCmd.PersistentFlags().Lookup("host-header-allowlist"))
+
 	rootCmd.PersistentFlags().Uint32P("timeout", "t", 0, "(DEPRECATED) USB operation timeout in milliseconds (default 0, never timeout)")
 	viper.BindPFlag("timeout", rootCmd.PersistentFlags().Lookup("timeout"))
 


### PR DESCRIPTION
This PR enables users to be able to define the `host-header-allowlist` in the configuration file. At the moment, if you attempt to set these values in the configuration file, they are not propagated to the variables used in the middleware due to how viper's marshaling works.

I would also propose that we remove the `enable-host-header-allowlist` flag from the configuration entirely as we can infer that this is what the user wants to do if `host-header-allowlist` configured. It can be a little confusing to define the list, but not have it actually take effect.