### PR TITLE
fix: Pipeline failures due to unsupported linux release

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -3,64 +3,13 @@ name: "Building release binaries on Linux"
 on: [push]
 
 jobs:
-
-  Ubuntu1804-Build:
-    name: Ubuntu1804
-    runs-on: ubuntu-18.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build binary
-        run: |
-          set -e -o pipefail
-          set -x
-          mkdir -p artifact/yubihsm-connector
-
-          sudo apt-get update && sudo  apt-get dist-upgrade -y
-          sudo apt-get install -y libusb-1.0.0-dev
-
-          export PATH=$PATH:/usr/local/go/bin:~/go/bin
-          if [[ ! -x $(command -v go ) ]]; then
-            curl -L --max-redirs 2 -o - https://golang.org/dl/go1.17.linux-amd64.tar.gz |\
-              sudo tar -C /usr/local -xzvf -
-          fi
-          if [[ ! -x $(command -v go-bin-deb) ]]; then
-            curl -L -o go-bin-deb.dpkg https://github.com/mh-cbon/go-bin-deb/releases/download/0.0.19/go-bin-deb-amd64.deb
-            sudo dpkg -i go-bin-deb.dpkg
-            sudo apt-get install --fix-missing
-          fi
-
-          make
-          strip --strip-all bin/yubihsm-connector
-          version=`bin/yubihsm-connector version`
-          go-bin-deb generate -f deb/deb.json -a amd64 --version=${version}-1
-          cp *.deb artifact/yubihsm-connector
-
-          ./bin/yubihsm-connector version
-          ./bin/yubihsm-connector --help
-
-          LICESE_DIR="artifact/yubihsm-connector/share/yubihsm-connector"
-          mkdir -p $LICESE_DIR
-          cp -r resources/release/licenses $LICESE_DIR/
-          for lf in $LICESE_DIR/licenses/*; do
-            chmod 644 $lf
-          done
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: yubihsm-connector-ubuntu1804-amd64
-          path: artifact
-
   Ubuntu2004-Build:
     name: Ubuntu2004
     runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build binary
         run: |

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build binary
         run: |

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build binary
         run: |


### PR DESCRIPTION
Pipelines are currently failing due to running on `Ubuntu-18.04` which was deprecated this year.