### PR TITLE
Fix memory leak in usbOpen error path

### DIFF
--- a/usb_windows.c
+++ b/usb_windows.c
@@ -448,6 +448,7 @@ Cleanup:
         {
             WinUsb_Free(ctx->usbInterface);
         }
+        free(ctx);
     }
 
     return error;


### PR DESCRIPTION
Add missing free(ctx) in the cleanup section when device initialization fails. This prevents memory leaks during USB device enumeration when devices fail to initialize.